### PR TITLE
mkdir before cping files up

### DIFF
--- a/src/Command/Pull.php
+++ b/src/Command/Pull.php
@@ -44,9 +44,7 @@ class Pull extends Command implements CommandInterface
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $container = $this->phpContainerName();
-        $files     = is_array($input->getArgument('files'))
-            ? $input->getArgument('files')
-            : [$input->getArgument('files')];
+        $files     = (array) $input->getArgument('files');
 
         foreach ($files as $file) {
             $srcPath = ltrim($file, '/');

--- a/src/Command/Watch.php
+++ b/src/Command/Watch.php
@@ -49,9 +49,10 @@ class Watch extends Command implements CommandInterface
         $output->writeln('');
 
         $command = sprintf(
-            'fswatch -r %s -e %s | xargs -n1 -I {} workflow sync {}',
+            'fswatch -r %s -e %s | xargs -n1 -I {} %s sync --ansi {}',
             implode(' ', $watches),
-            implode(' -e ', $excludes)
+            implode(' -e ', $excludes),
+            realpath(__DIR__ . '/../../bin/workflow')
         );
 
         $this->runProcessShowingOutput($output, $command);

--- a/test/Command/PullTest.php
+++ b/test/Command/PullTest.php
@@ -57,7 +57,7 @@ class PullTest extends AbstractTestCommand
     {
         $this->useValidEnvironment();
 
-        $this->input->getArgument('files')->shouldBeCalledTimes(2)->willReturn(['some-file.txt']);
+        $this->input->getArgument('files')->shouldBeCalled()->willReturn(['some-file.txt']);
 
         $this->processTestNoOutput(
             "docker exec m2-php php -r \"echo file_exists('/var/www/some-file.txt') ? 'true' : 'false';\""
@@ -76,7 +76,7 @@ class PullTest extends AbstractTestCommand
     {
         $this->useValidEnvironment();
 
-        $this->input->getArgument('files')->shouldBeCalledTimes(2)->willReturn(['some-file.txt']);
+        $this->input->getArgument('files')->shouldBeCalled()->willReturn(['some-file.txt']);
 
         $this->processTestNoOutput(
             "docker exec m2-php php -r \"echo file_exists('/var/www/some-file.txt') ? 'true' : 'false';\""

--- a/test/Command/PushTest.php
+++ b/test/Command/PushTest.php
@@ -50,8 +50,9 @@ class PushTest extends AbstractTestCommand
     {
         $this->useValidEnvironment();
 
-        $this->input->getArgument('files')->shouldBeCalledTimes(2)->willReturn(['some-file.txt']);
+        $this->input->getArgument('files')->shouldBeCalled()->willReturn(['some-file.txt']);
 
+        $this->processTest('docker exec m2-php mkdir -p /var/www');
         $this->processTest('docker cp some-file.txt m2-php:/var/www/');
         $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data /var/www/some-file.txt');
         $this->output->writeln("<info> + some-file.txt > m2-php </info>")->shouldBeCalled();
@@ -64,8 +65,9 @@ class PushTest extends AbstractTestCommand
         $this->useValidEnvironment();
 
         $filePath = realpath('some-file.txt');
-        $this->input->getArgument('files')->shouldBeCalledTimes(2)->willReturn([$filePath]);
+        $this->input->getArgument('files')->shouldBeCalled()->willReturn([$filePath]);
 
+        $this->processTest('docker exec m2-php mkdir -p /var/www');
         $this->processTest('docker cp some-file.txt m2-php:/var/www/');
         $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data /var/www/some-file.txt');
         $this->output->writeln("<info> + some-file.txt > m2-php </info>")->shouldBeCalled();
@@ -77,7 +79,7 @@ class PushTest extends AbstractTestCommand
     {
         $this->useValidEnvironment();
 
-        $this->input->getArgument('files')->shouldBeCalledTimes(2)->willReturn(['some-bad-file.txt']);
+        $this->input->getArgument('files')->shouldBeCalled()->willReturn(['some-bad-file.txt']);
         $this->output->writeln('Looks like "some-bad-file.txt" doesn\'t exist')->shouldBeCalled();
 
         $this->command->execute($this->input->reveal(), $this->output->reveal());

--- a/test/Command/WatchTest.php
+++ b/test/Command/WatchTest.php
@@ -58,7 +58,12 @@ class WatchTest extends AbstractTestCommand
 
         $includes = 'app pub composer.json';
         $excludes = '-e ".*__jb_.*$" -e ".*swp$" -e ".*swpx$"';
-        $expected  = sprintf('fswatch -r %s %s | xargs -n1 -I {} workflow sync {}', $includes, $excludes);
+        $expected  = sprintf(
+            'fswatch -r %s %s | xargs -n1 -I {} %s sync --ansi {}',
+            $includes,
+            $excludes,
+            realpath(__DIR__ . '/../../bin/workflow')
+        );
         
         $this->processTest($expected);
         $this->output->writeln('<info>Watching for file changes...</info>')->shouldBeCalled();
@@ -74,7 +79,12 @@ class WatchTest extends AbstractTestCommand
 
         $includes = 'custom-dir app pub composer.json';
         $excludes = '-e ".*__jb_.*$" -e ".*swp$" -e ".*swpx$"';
-        $expected  = sprintf('fswatch -r %s %s | xargs -n1 -I {} workflow sync {}', $includes, $excludes);
+        $expected  = sprintf(
+            'fswatch -r %s %s | xargs -n1 -I {} %s sync --ansi {}',
+            $includes,
+            $excludes,
+            realpath(__DIR__ . '/../../bin/workflow')
+        );
 
         $this->processTest($expected);
         $this->output->writeln('<info>Watching for file changes...</info>')->shouldBeCalled();
@@ -90,7 +100,12 @@ class WatchTest extends AbstractTestCommand
 
         $includes = 'custom-dir';
         $excludes = '-e ".*__jb_.*$" -e ".*swp$" -e ".*swpx$"';
-        $expected  = sprintf('fswatch -r %s %s | xargs -n1 -I {} workflow sync {}', $includes, $excludes);
+        $expected  = sprintf(
+            'fswatch -r %s %s | xargs -n1 -I {} %s sync --ansi {}',
+            $includes,
+            $excludes,
+            realpath(__DIR__ . '/../../bin/workflow')
+        );
 
         $this->processTest($expected);
         $this->output->writeln('<info>Watching for file changes...</info>')->shouldBeCalled();


### PR DESCRIPTION
* Recursively create parent directory on container before cp'ing file in
* Force ansi for watch command
* Simplify arg fetching
* Formatting
* Use local binary when piping instead of system