### PR TITLE
Escape file names in push command

### DIFF
--- a/src/Command/Push.php
+++ b/src/Command/Push.php
@@ -50,9 +50,22 @@ class Push extends Command implements CommandInterface
                 return;
             }
 
-            $mkdirCommand = sprintf('docker exec %s mkdir -p %s', $container, dirname($destFile));
-            $copyCommand  = sprintf('docker cp %s %s:%s', $srcPath, $container, $destPath);
-            $chownCommand = sprintf('docker exec %s chown -R www-data:www-data %s', $container, $destFile);
+            $mkdirCommand = sprintf(
+                'docker exec %s mkdir -p %s',
+                $container,
+                dirname($destFile)
+            );
+            $copyCommand  = sprintf(
+                'docker cp %s %s:%s',
+                escapeshellarg($srcPath),
+                $container,
+                escapeshellarg($destPath)
+            );
+            $chownCommand = sprintf(
+                'docker exec %s chown -R www-data:www-data %s',
+                $container,
+                escapeshellarg($destFile)
+            );
 
             $this->runProcessShowingOutput($output, $mkdirCommand);
             $this->runProcessShowingOutput($output, $copyCommand);

--- a/src/Command/Push.php
+++ b/src/Command/Push.php
@@ -53,7 +53,7 @@ class Push extends Command implements CommandInterface
             $mkdirCommand = sprintf(
                 'docker exec %s mkdir -p %s',
                 $container,
-                dirname($destFile)
+                escapeshellarg(dirname($destFile))
             );
             $copyCommand  = sprintf(
                 'docker cp %s %s:%s',

--- a/test/Command/PushTest.php
+++ b/test/Command/PushTest.php
@@ -53,8 +53,8 @@ class PushTest extends AbstractTestCommand
         $this->input->getArgument('files')->shouldBeCalled()->willReturn(['some-file.txt']);
 
         $this->processTest('docker exec m2-php mkdir -p /var/www');
-        $this->processTest('docker cp some-file.txt m2-php:/var/www/');
-        $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data /var/www/some-file.txt');
+        $this->processTest('docker cp \'some-file.txt\' m2-php:\'/var/www/\'');
+        $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data \'/var/www/some-file.txt\'');
         $this->output->writeln("<info> + some-file.txt > m2-php </info>")->shouldBeCalled();
 
         $this->command->execute($this->input->reveal(), $this->output->reveal());
@@ -68,8 +68,8 @@ class PushTest extends AbstractTestCommand
         $this->input->getArgument('files')->shouldBeCalled()->willReturn([$filePath]);
 
         $this->processTest('docker exec m2-php mkdir -p /var/www');
-        $this->processTest('docker cp some-file.txt m2-php:/var/www/');
-        $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data /var/www/some-file.txt');
+        $this->processTest('docker cp \'some-file.txt\' m2-php:\'/var/www/\'');
+        $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data \'/var/www/some-file.txt\'');
         $this->output->writeln("<info> + some-file.txt > m2-php </info>")->shouldBeCalled();
 
         $this->command->execute($this->input->reveal(), $this->output->reveal());

--- a/test/Command/PushTest.php
+++ b/test/Command/PushTest.php
@@ -52,7 +52,7 @@ class PushTest extends AbstractTestCommand
 
         $this->input->getArgument('files')->shouldBeCalled()->willReturn(['some-file.txt']);
 
-        $this->processTest('docker exec m2-php mkdir -p /var/www');
+        $this->processTest('docker exec m2-php mkdir -p \'/var/www\'');
         $this->processTest('docker cp \'some-file.txt\' m2-php:\'/var/www/\'');
         $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data \'/var/www/some-file.txt\'');
         $this->output->writeln("<info> + some-file.txt > m2-php </info>")->shouldBeCalled();
@@ -67,7 +67,7 @@ class PushTest extends AbstractTestCommand
         $filePath = realpath('some-file.txt');
         $this->input->getArgument('files')->shouldBeCalled()->willReturn([$filePath]);
 
-        $this->processTest('docker exec m2-php mkdir -p /var/www');
+        $this->processTest('docker exec m2-php mkdir -p \'/var/www\'');
         $this->processTest('docker cp \'some-file.txt\' m2-php:\'/var/www/\'');
         $this->processTestNoOutput('docker exec m2-php chown -R www-data:www-data \'/var/www/some-file.txt\'');
         $this->output->writeln("<info> + some-file.txt > m2-php </info>")->shouldBeCalled();


### PR DESCRIPTION
I tried pushing a file with spaces in it:

`workflow push 'var/fps_import/incoming/Price File - 100100-26052017112827.csv'` and docker cries like a baby:

```
"docker cp" requires exactly 2 argument(s).
See 'docker cp --help'.

Usage:  docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
	docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH

Copy files/folders between a container and the local filesystem
```

It's because we build the command without escaping arguments. This should probably be fixed universally somehow, but time is not on ones side.