### PR TITLE
Dump databases as mysql root user

### DIFF
--- a/src/Command/DatabaseDump.php
+++ b/src/Command/DatabaseDump.php
@@ -54,12 +54,10 @@ class DatabaseDump extends Command implements CommandInterface
     private function getDbDetails(InputInterface $input) : array
     {
         $envVars   = $this->getDevEnvironmentVars();
-        $dbDetails = [];
-
-        $dbDetails['user'] = $envVars['MYSQL_USER'] ?? 'docker';
-        $dbDetails['pass'] = $envVars['MYSQL_PASSWORD'] ?? 'docker';
-        $dbDetails['db']   = $input->getOption('database') ?? $envVars['MYSQL_DATABASE'] ?? 'docker';
-
-        return $dbDetails;
+        return [
+            'user' => 'root',
+            'pass' => $envVars['MYSQL_ROOT_PASSWORD'] ?? 'docker',
+            'db'   => $input->getOption('database') ?? $envVars['MYSQL_DATABASE'] ?? 'docker'
+        ];
     }
 }

--- a/test/Command/DatabaseDumpTest.php
+++ b/test/Command/DatabaseDumpTest.php
@@ -47,7 +47,7 @@ class DatabaseDumpTest extends AbstractTestCommand
 
         $this->input->getOption('database')->willReturn(null);
 
-        $this->commandLine->runQuietly('docker exec -i m2-db mysqldump -udocker -pdocker docker > dump.sql')
+        $this->commandLine->runQuietly('docker exec -i m2-db mysqldump -uroot -pdocker docker > dump.sql')
             ->shouldBeCalled();
 
         $this->output->writeln('<info>Database dump saved to ./dump.sql</info>')->shouldBeCalled();
@@ -61,7 +61,7 @@ class DatabaseDumpTest extends AbstractTestCommand
 
         $this->input->getOption('database')->willReturn('custom_db');
 
-        $this->commandLine->runQuietly('docker exec -i m2-db mysqldump -udocker -pdocker custom_db > dump.sql')
+        $this->commandLine->runQuietly('docker exec -i m2-db mysqldump -uroot -pdocker custom_db > dump.sql')
             ->shouldBeCalled();
         $this->output->writeln('<info>Database dump saved to ./dump.sql</info>')->shouldBeCalled();
 


### PR DESCRIPTION
Dump databases as root user, tripped me up a few times with integration tests and migration db's. This just makes it easier.