### PR TITLE
feat(option): added mount option to 'start' and 'up'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "m1/env": "^2.1",
         "aydin-hassan/osx-rx-fswatch": "^1.0",
         "tightenco/collect": "^5.4",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "webmozart/path-util": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5da83d318ae46d2f930cd9550ca81539",
+    "content-hash": "b6424c0ef5a855ff36ab89299d360bcf",
     "packages": [
         {
             "name": "aydin-hassan/osx-rx-fswatch",
@@ -1114,6 +1114,102 @@
                 "timer"
             ],
             "time": "2017-03-14T01:10:32+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "packages-dev": [
@@ -2729,56 +2825,6 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/src/Command/Start.php
+++ b/src/Command/Start.php
@@ -19,8 +19,9 @@ class Start extends Command implements CommandInterface
     {
         $this
             ->setName('start')
-            ->setDescription('Runs build, up and watch comands')
-            ->addOption('prod', 'p', InputOption::VALUE_OPTIONAL, 'Ommits development configurations');
+            ->setDescription('Runs build, up and watch commands')
+            ->addOption('prod', 'p', InputOption::VALUE_OPTIONAL, 'Omits development configurations')
+            ->addOption('mount', 'm', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'Directories to mount at run time');
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -30,9 +31,15 @@ class Start extends Command implements CommandInterface
         $pullCommand  = $this->getApplication()->find('pull');
         $watchCommand = $this->getApplication()->find('watch');
 
-        $buildCommand->run($input, $output);
+        $buildCommand->run(new ArrayInput([
+            new InputOption('prod', $input->getOption('prod'))
+        ]), $output);
+
         $upCommand->run($input, $output);
         $pullCommand->run(new ArrayInput(['files' => ['.docker/composer-cache']]), $output);
-        $watchCommand->run($input, $output);
+
+        if (count($input->getOption('mount')) === 0) {
+            $watchCommand->run($input, $output);
+        }
     }
 }

--- a/src/Command/Up.php
+++ b/src/Command/Up.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\PathUtil\Path;
 
 /**
  * @author Michael Woodward <michael@wearejh.com>
@@ -29,7 +31,8 @@ class Up extends Command implements CommandInterface
         $this
             ->setName('up')
             ->setDescription('Uses docker-compose to start the containers')
-            ->addOption('prod', 'p', InputOption::VALUE_OPTIONAL, 'Omits development configurations');
+            ->addOption('prod', 'p', InputOption::VALUE_OPTIONAL, 'Omits development configurations')
+            ->addOption('mount', 'm', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'Directories to mount at run time');
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -38,8 +41,49 @@ class Up extends Command implements CommandInterface
             ? 'docker-compose.prod.yml'
             : 'docker-compose.dev.yml';
 
-        $this->commandLine->run(sprintf('docker-compose -f docker-compose.yml -f %s up -d', $envDockerFile));
+        $yaml = $this->generateYaml([
+            'docker-compose.yml',
+            $envDockerFile
+        ], $input->getOption('mount'));
+
+        // now echo the yaml and pipe into docker-compose
+        // Note: This is because I couldn't get InputStream to work.
+        $this->commandLine->run(sprintf('echo "%s" | docker-compose -f - up -d', $yaml));
 
         $output->writeln('<info>Containers started</info>');
+    }
+
+    /**
+     * @param array $paths - docker-compose files to merge
+     * @param array $mounts - paths to be converted into volumes
+     * @return string
+     */
+    static function generateYaml($paths = [], $mounts = []) {
+        $mergedYaml = collect($paths)
+            ->map(function($path) {
+                return Yaml::parse(file_get_contents($path));
+            })
+            ->reduce(function($carry, $arr) {
+                return array_merge_recursive($carry, $arr);
+            }, []);
+
+        // do the merging that docker-compose would normally do
+        // Hack because I don't know how to stop 'version' becoming an array because of 'array_merge_recursive' above
+        $mergedYaml['version'] = '2';
+
+        // convert path inputs to valid docker-volume definitions
+        $dirs = collect($mounts)
+            ->map(function($path) {
+                return Path::canonicalize($path);
+            })
+            ->map(function($path) {
+                return sprintf('./%s:/var/www/%s', $path, $path);
+            })
+            ->toArray();
+
+        // merge the mounted paths with previous volumes
+        $mergedYaml['services']['php']['volumes'] = array_merge($mergedYaml['services']['php']['volumes'], $dirs);
+
+        return Yaml::dump($mergedYaml);
     }
 }

--- a/test/Command/StartTest.php
+++ b/test/Command/StartTest.php
@@ -11,6 +11,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Michael Woodward <michael@wearejh.com>
@@ -77,8 +78,9 @@ class StartTest extends AbstractTestCommand
     {
         static::assertEquals('start', $this->command->getName());
         static::assertEquals([], $this->command->getAliases());
-        static::assertEquals('Runs build, up and watch comands', $this->command->getDescription());
+        static::assertEquals('Runs build, up and watch commands', $this->command->getDescription());
         static::assertArrayHasKey('prod', $this->command->getDefinition()->getOptions());
+        static::assertArrayHasKey('mount', $this->command->getDefinition()->getOptions());
     }
 
     public function testCommandRunsAllSubCommands()
@@ -89,9 +91,11 @@ class StartTest extends AbstractTestCommand
         $this->application->find('watch')->shouldBeCalled();
 
         $expectedPullInput = new ArrayInput(['files' => ['.docker/composer-cache']]);
+        $expectedBuildInput = new ArrayInput([
+            new InputOption('prod', false)
+        ]);
 
-        $this->buildCommand->run($this->input, $this->output)->shouldBeCalled();
-        $this->upCommand->run($this->input, $this->output)->shouldBeCalled();
+        $this->buildCommand->run($expectedBuildInput, $this->output)->shouldBeCalled();
         $this->upCommand->run($this->input, $this->output)->shouldBeCalled();
         $this->pullCommand->run($expectedPullInput, $this->output)->shouldBeCalled();
         $this->watchCommand->run($this->input, $this->output)->shouldBeCalled();

--- a/test/Command/UpTest.php
+++ b/test/Command/UpTest.php
@@ -3,6 +3,7 @@
 namespace Jh\WorkflowTest\Command;
 
 use Jh\Workflow\Command\Up;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @author Michael Woodward <michael@wearejh.com>
@@ -28,14 +29,51 @@ class UpTest extends AbstractTestCommand
         static::assertArrayHasKey('prod', $this->command->getDefinition()->getOptions());
     }
 
-    public function testStopsDevelopmentMode()
+    public function testYamlConfigurationCreatedWithoutMountOption() {
+
+        $mountOption = [];
+
+        $yaml = Up::generateYaml([
+            'docker-compose.yml',
+            'docker-compose.dev.yml'
+        ], $mountOption);
+
+        $this->assertStringEqualsFile(
+            __DIR__ . '/../fixtures/yaml/without-mount.yml',
+            $yaml
+        );
+    }
+
+    public function testYamlConfigurationCreatedWithMountOption() {
+
+        $mountOption = ['./app/code', 'app/design'];
+
+        $yaml = Up::generateYaml([
+            'docker-compose.yml',
+            'docker-compose.dev.yml'
+        ], $mountOption);
+
+        $this->assertStringEqualsFile(
+            __DIR__ . '/../fixtures/yaml/with-multi-mount.yml',
+            $yaml
+        );
+    }
+
+    public function testUpRunsInDevelopmentMode()
     {
         $this->useValidEnvironment();
 
+        $mountOption = [];
         $this->input->getOption('prod')->willReturn(false);
+        $this->input->getOption('mount')->willReturn($mountOption);
+
+        $expectedYaml = Up::generateYaml([
+            'docker-compose.yml',
+            'docker-compose.dev.yml'
+        ], $mountOption);
 
         $this->commandLine
-            ->run('docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d')
+            ->run(sprintf('echo "%s" | docker-compose -f - up -d', $expectedYaml))
             ->shouldBeCalled();
 
         $this->output->writeln('<info>Containers started</info>')->shouldBeCalled();
@@ -43,14 +81,43 @@ class UpTest extends AbstractTestCommand
         $this->command->execute($this->input->reveal(), $this->output->reveal());
     }
 
-    public function testStopsProductionMode()
+    public function testUpRunsInProductionMode()
     {
         $this->useValidEnvironment();
 
+        $mountOption = [];
         $this->input->getOption('prod')->willReturn(true);
+        $this->input->getOption('mount')->willReturn($mountOption);
+
+        $expectedYaml = Up::generateYaml([
+            'docker-compose.yml',
+            'docker-compose.prod.yml'
+        ], $mountOption);
 
         $this->commandLine
-            ->run('docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d')
+            ->run(sprintf('echo "%s" | docker-compose -f - up -d', $expectedYaml))
+            ->shouldBeCalled();
+
+        $this->output->writeln('<info>Containers started</info>')->shouldBeCalled();
+
+        $this->command->execute($this->input->reveal(), $this->output->reveal());
+    }
+
+    public function testUpRunsInDevelopmentModeWithSingleMountOption()
+    {
+        $this->useValidEnvironment();
+
+        $mountOption = ['app/code'];
+        $this->input->getOption('prod')->willReturn(false);
+        $this->input->getOption('mount')->willReturn($mountOption);
+
+        $expectedYaml = Up::generateYaml([
+            'docker-compose.yml',
+            'docker-compose.dev.yml'
+        ], $mountOption);
+
+        $this->commandLine
+            ->run(sprintf('echo "%s" | docker-compose -f - up -d', $expectedYaml))
             ->shouldBeCalled();
 
         $this->output->writeln('<info>Containers started</info>')->shouldBeCalled();

--- a/test/fixtures/valid-env/docker-compose.prod.yml
+++ b/test/fixtures/valid-env/docker-compose.prod.yml
@@ -1,0 +1,32 @@
+version: '2'
+
+volumes:
+    app-var:
+
+services:
+    nginx:
+        volumes:
+            - /etc/letsencrypt:/etc/letsencrypt
+        env_file:
+            - .docker/production.env
+
+    php:
+        env_file:
+            - .docker/production.env
+        volumes:
+            - app-var:/var/www/var
+
+    db:
+        env_file:
+            - .docker/production.env
+
+#    rabbitmq:
+#        env_file:
+#            - ./.docker/production.env
+
+#    varnish:
+#        image: million12/varnish
+#        ports:
+#            - "80:80"
+#        env_file:
+#            - ./.docker/production.env

--- a/test/fixtures/yaml/with-multi-mount.yml
+++ b/test/fixtures/yaml/with-multi-mount.yml
@@ -1,0 +1,13 @@
+version: '2'
+volumes:
+    db-data: null
+    app-pub: null
+    app-var: null
+    app-env: null
+services:
+    nginx: { container_name: selco-m2, image: 'nginx:stable-alpine', volumes: ['app-pub:/var/www/pub', '.docker/nginx/sites:/etc/nginx/conf.d', '.docker/certs:/etc/letsencrypt'], working_dir: /var/www, ports: ['80:80', '443:443'], env_file: [./.docker/local.env] }
+    php: { container_name: selco-m2-php, image: wearejh/selco-m2, build: { context: ./, dockerfile: app.php.dockerfile }, volumes: ['app-pub:/var/www/pub', 'app-env:/var/www/app/etc', '~/.composer/auth.json:/root/.composer/auth.json', '.docker/composer-cache:/var/www/.docker/composer-cache', './app/code:/var/www/app/code', './app/design:/var/www/app/design'], working_dir: /var/www, ports: [9000], env_file: [.docker/local.env] }
+    db: { container_name: selco-m2-db, image: 'mysql:5.6', volumes: ['db-data:/var/lib/mysql', '.docker/db/:/docker-entrypoint-initdb.d/'], ports: ['3306:3306'], restart: unless-stopped, env_file: [./.docker/local.env] }
+    redis: { container_name: selco-m2-redis, image: 'redis:3-alpine', ports: ['6379:6379'] }
+    mail: { container_name: selco-m2-mail, image: schickling/mailcatcher, ports: [1025, '1080:1080'] }
+    blackfire: { container_name: selco-m2-blackfire, image: blackfire/blackfire, env_file: [.docker/local.env] }

--- a/test/fixtures/yaml/with-single-mount.yml
+++ b/test/fixtures/yaml/with-single-mount.yml
@@ -1,0 +1,13 @@
+version: '2'
+volumes:
+    db-data: null
+    app-pub: null
+    app-var: null
+    app-env: null
+services:
+    nginx: { container_name: selco-m2, image: 'nginx:stable-alpine', volumes: ['app-pub:/var/www/pub', '.docker/nginx/sites:/etc/nginx/conf.d', '.docker/certs:/etc/letsencrypt'], working_dir: /var/www, ports: ['80:80', '443:443'], env_file: [./.docker/local.env] }
+    php: { container_name: selco-m2-php, image: wearejh/selco-m2, build: { context: ./, dockerfile: app.php.dockerfile }, volumes: ['app-pub:/var/www/pub', 'app-env:/var/www/app/etc', '~/.composer/auth.json:/root/.composer/auth.json', '.docker/composer-cache:/var/www/.docker/composer-cache', './app/code:/var/www/app/code'], working_dir: /var/www, ports: [9000], env_file: [.docker/local.env] }
+    db: { container_name: selco-m2-db, image: 'mysql:5.6', volumes: ['db-data:/var/lib/mysql', '.docker/db/:/docker-entrypoint-initdb.d/'], ports: ['3306:3306'], restart: unless-stopped, env_file: [./.docker/local.env] }
+    redis: { container_name: selco-m2-redis, image: 'redis:3-alpine', ports: ['6379:6379'] }
+    mail: { container_name: selco-m2-mail, image: schickling/mailcatcher, ports: [1025, '1080:1080'] }
+    blackfire: { container_name: selco-m2-blackfire, image: blackfire/blackfire, env_file: [.docker/local.env] }

--- a/test/fixtures/yaml/without-mount.yml
+++ b/test/fixtures/yaml/without-mount.yml
@@ -1,0 +1,13 @@
+version: '2'
+volumes:
+    db-data: null
+    app-pub: null
+    app-var: null
+    app-env: null
+services:
+    nginx: { container_name: selco-m2, image: 'nginx:stable-alpine', volumes: ['app-pub:/var/www/pub', '.docker/nginx/sites:/etc/nginx/conf.d', '.docker/certs:/etc/letsencrypt'], working_dir: /var/www, ports: ['80:80', '443:443'], env_file: [./.docker/local.env] }
+    php: { container_name: selco-m2-php, image: wearejh/selco-m2, build: { context: ./, dockerfile: app.php.dockerfile }, volumes: ['app-pub:/var/www/pub', 'app-env:/var/www/app/etc', '~/.composer/auth.json:/root/.composer/auth.json', '.docker/composer-cache:/var/www/.docker/composer-cache'], working_dir: /var/www, ports: [9000], env_file: [.docker/local.env] }
+    db: { container_name: selco-m2-db, image: 'mysql:5.6', volumes: ['db-data:/var/lib/mysql', '.docker/db/:/docker-entrypoint-initdb.d/'], ports: ['3306:3306'], restart: unless-stopped, env_file: [./.docker/local.env] }
+    redis: { container_name: selco-m2-redis, image: 'redis:3-alpine', ports: ['6379:6379'] }
+    mail: { container_name: selco-m2-mail, image: schickling/mailcatcher, ports: [1025, '1080:1080'] }
+    blackfire: { container_name: selco-m2-blackfire, image: blackfire/blackfire, env_file: [.docker/local.env] }


### PR DESCRIPTION
This change allows the user to provide paths at runtime --mount flag.
These paths will be appended to the PHP container's 'volumes'.

This is to replace file-watching in situations where you know which
files/folders you'll be working in.

eg: 

```sh
# Start example 
workflow start --mount app/code/<vendor>

# Up example
workflow up --mount app/code/<vendor>

# Multiple paths example
workflow start --mount app/code/<vendor> app/design/frontend/<vendor>default
```

It works by reading the `docker-compose.yml` & `docker.compose.env.yml` files manually. Once in PHP we add the volumes to the services-php-volumes array & then convert back to YML.

Finally we use the `-f -` feature of docker-compose which allows configuration to be passed via stdin.

I updated tests, and added a handful of new ones.

This is non-destructive as it does not alter any existing features - it could be used on existing projects without issue