### PR TITLE
change XDEBUG_CONFIG=remote_host for local dev

### DIFF
--- a/templates/docker/env/local.env.dist
+++ b/templates/docker/env/local.env.dist
@@ -30,7 +30,7 @@ MAIL_PORT=1025
 
 ## Xdebug config
 XDEBUG_IDE_KEY=PHPSTORM
-XDEBUG_CONFIG=remote_host=10.254.254.254
+XDEBUG_CONFIG=remote_host=docker.for.mac.host.internal
 XDEBUG_ENABLE=true
 PHP_IDE_CONFIG=serverName={project-domain}
 


### PR DESCRIPTION
For easier Xdebug setup.

Not sure if `templates/docker/env/production.env.dist` should be changed also?