### PR TITLE
Use Docker to create the project and update deps

### DIFF
--- a/src/NewProject/Step/ComposerJson.php
+++ b/src/NewProject/Step/ComposerJson.php
@@ -60,7 +60,11 @@ class ComposerJson implements StepInterface
 
         $output->success('Updating composer lock file');
         try {
-            $this->commandLine->run('composer update --ignore-platform-reqs --prefer-dist -q');
+            $command =  'docker run --rm ';
+            $command .= '-v %s:/root/build -v %s/.composer/cache:/root/.composer/cache ';
+            $command .= 'wearejh/ci-build-env composer update --prefer-dist -qo';
+
+            $this->commandLine->run(sprintf($command, getcwd(), getenv('HOME')));
         } catch (ProcessFailedException $e) {
             throw new \RuntimeException('Could not update composer lock file');
         }

--- a/src/NewProject/Step/CreateProject.php
+++ b/src/NewProject/Step/CreateProject.php
@@ -34,11 +34,16 @@ class CreateProject implements StepInterface
     {
         $output->success(sprintf('Running composer create-project into %s', $details->getProjectName()));
 
-        $cmdFormat =  'composer create-project -q --repository-url=https://%s:%s@repo.magento.com/ ';
-        $cmdFormat .= 'magento/project-%s-edition %s --prefer-dist --ignore-platform-reqs';
+        $cmdFormat =  'docker run --rm ';
+        $cmdFormat .= '-v %s:/root/build -v %s/.composer/cache:/root/.composer/cache ';
+        $cmdFormat .= 'wearejh/ci-build-env ';
+        $cmdFormat .= 'composer create-project -q --repository-url=https://%s:%s@repo.magento.com/ ';
+        $cmdFormat .= 'magento/project-%s-edition %s --prefer-dist';
 
         $command = sprintf(
             $cmdFormat,
+            getcwd(),
+            getenv('HOME'),
             $details->getPubKey(),
             $details->getPrivKey(),
             $details->getVersion(),


### PR DESCRIPTION
Originally added to feature/varnish #77 by @mikeymike but we agreed this should be PR'd irrespective of that work so I've rebased it out.

`workflow build` has a tendency to fail as a byproduct of using `composer update --ignore-platform-reqs` on the host, which does not necessarily use the same PHP version and for my project (Trend, on Commerce Cloud) we wind up having a requirement for `php >= 7.1` baked into the lock file which conflicts with the actual `php ^7.0` installed in container & on the Cloud server.

By initially building with a 7.0 container we can ensure compatibility with the destination env and don't need to ignore platform requirements during update.

Suggested action after merge: rebase feature/varnish branch to remove these changes and mitigate conflicts/dirt in history.