### PR TITLE
add db:cli [dc] command to connect to mysql cli

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -54,6 +54,7 @@ return [
         $app->add($c->get(Command\Php::class));
         $app->add($c->get(Command\Exec::class));
         $app->add($c->get(Command\Delete::class));
+        $app->add($c->get(Command\DatabaseCliCommand::class));
         $app->add($c->get(Command\DatabaseDump::class));
 
         $eventLoop = $c->get(LoopInterface::class);

--- a/app/config.php
+++ b/app/config.php
@@ -46,7 +46,6 @@ return [
         $app->add($c->get(Command\ComposerUpdate::class));
         $app->add($c->get(Command\ComposerInstall::class));
         $app->add($c->get(Command\ComposerRequire::class));
-        $app->add($c->get(Command\Sql::class));
         $app->add($c->get(Command\Ssh::class));
         $app->add($c->get(Command\NginxReload::class));
         $app->add($c->get(Command\XdebugLoopback::class));
@@ -54,8 +53,9 @@ return [
         $app->add($c->get(Command\Php::class));
         $app->add($c->get(Command\Exec::class));
         $app->add($c->get(Command\Delete::class));
-        $app->add($c->get(Command\DatabaseCliCommand::class));
+        $app->add($c->get(Command\DatabaseCli::class));
         $app->add($c->get(Command\DatabaseDump::class));
+        $app->add($c->get(Command\DatabaseExec::class));
 
         $eventLoop = $c->get(LoopInterface::class);
 

--- a/src/Command/DatabaseCli.php
+++ b/src/Command/DatabaseCli.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Aneurin "Anny" Barker Snook <anny@wearejh.com>
  */
-class DatabaseCliCommand extends Command implements CommandInterface
+class DatabaseCli extends Command implements CommandInterface
 {
     use DatabaseConnectorTrait;
 

--- a/src/Command/DatabaseCliCommand.php
+++ b/src/Command/DatabaseCliCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Jh\Workflow\Command;
+
+use Jh\Workflow\CommandLine;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Aneurin "Anny" Barker Snook <anny@wearejh.com>
+ */
+class DatabaseCliCommand extends Command implements CommandInterface
+{
+    use DatabaseConnectorTrait;
+
+    /**
+     * @var CommandLine
+     */
+    private $cl;
+
+    public function __construct(CommandLine $cl)
+    {
+        parent::__construct();
+        $this->cl = $cl;
+    }
+
+    public function configure()
+    {
+        $this->setName('db:cli')
+            ->setAliases(['dc'])
+            ->setDescription('Connect to MySQL CLI')
+            ->addOption('database', 'd', InputOption::VALUE_REQUIRED, 'Optional database to connect to');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        list($user, $pass, $db) = array_values($this->getDbDetails($input));
+        $db = $input->getOption('database') ?: $db;
+
+        $command = "docker-compose exec db mysql -u {$user} -p{$pass} {$db}\n";
+        $this->cl->runInteractively($command);
+    }
+}

--- a/src/Command/DatabaseConnectorTrait.php
+++ b/src/Command/DatabaseConnectorTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jh\Workflow\Command;
+
+trait DatabaseConnectorTrait
+{
+    use DockerAwareTrait;
+
+    private function getDbDetails() : array
+    {
+        $envVars   = $this->getDevEnvironmentVars();
+        return [
+            'user' => 'root',
+            'pass' => $envVars['MYSQL_ROOT_PASSWORD'] ?? 'docker',
+            'db'   => $envVars['MYSQL_DATABASE'] ?? 'docker'
+        ];
+    }
+}


### PR DESCRIPTION
These changes add a new `workflow db:cli` or if you prefer, `workflow dc` command that puts you straight into a MySQL CLI.

There is also some refactoring of `workflow db-dump` which is now `workflow db:dump` for namespace consistency. I've also removed the use of `extract()` there for reasons of security and clarity (although two others remain in the wider codebase!)