### PR TITLE
Add global workflow repository to composer.json programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,10 @@ Make sure you have `fswatch` installed. You can install via homebrew:
 brew install fswatch
 ```
 
-Add the following to `~/.composer/composer.json`:
+Run the following commands:
 
 ```
-"repositories" : [
-    {
-        "type": "vcs",
-        "url": "git@github.com:WeareJH/workflow.git"
-    }
-]
-```
-
-Then run:
-
-```
+composer global config repositories.workflow vcs git@github.com:wearejh/workflow
 composer global require wearejh/workflow:dev-master
 ```
 


### PR DESCRIPTION
Since it's possible to add Composer repositories via the command line, we should. Especially because editing JSON is potentially difficult if you habitually add trailing commas. From [the docs](https://getcomposer.org/doc/03-cli.md#modifying-repositories):

> In addition to modifying the config section, the config command also supports making changes to the repositories section by using it the following way:
> 
> ```php composer.phar config repositories.foo vcs https://github.com/foo/bar```
