### PR TITLE
Add setup:upgrade magento command wrapper

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -39,6 +39,7 @@ return [
         $app->add($c->get(Command\MagentoCompile::class));
         $app->add($c->get(Command\MagentoModuleEnable::class));
         $app->add($c->get(Command\MagentoModuleDisable::class));
+        $app->add($c->get(Command\MagentoSetupUpgrade::class));
         $app->add($c->get(Command\Pull::class));
         $app->add($c->get(Command\Push::class));
         $app->add($c->get(Command\Watch::class));

--- a/src/Command/MagentoSetupUpgrade.php
+++ b/src/Command/MagentoSetupUpgrade.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\Workflow\Command;
+
+use Jh\Workflow\CommandLine;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @author Diego Cabrejas <diego@wearejh.com>
+ */
+class MagentoSetupUpgrade extends Command implements CommandInterface
+{
+    use DockerAwareTrait;
+
+    /**
+     * Option to skip deletion of generated/code directory
+     */
+    const INPUT_KEY_KEEP_GENERATED = 'keep-generated';
+
+    /**
+     * @var CommandLine
+     */
+    private $commandLine;
+
+    public function __construct(CommandLine $commandLine)
+    {
+        parent::__construct();
+        $this->commandLine = $commandLine;
+    }
+
+    public function configure()
+    {
+        $options = [
+            new InputOption(
+                self::INPUT_KEY_KEEP_GENERATED,
+                null,
+                InputOption::VALUE_NONE,
+                'Prevents generated files from being deleted. ' . PHP_EOL .
+                'We discourage using this option except when deploying to production. ' . PHP_EOL .
+                'Consult your system integrator or administrator for more information.'
+            )
+        ];
+
+        $this
+            ->setName('setup:upgrade')
+            ->setDescription('Upgrades the Magento application and updates the config.php file')
+            ->setDefinition($options);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->phpContainerName();
+        $option    = $input->getOption(self::INPUT_KEY_KEEP_GENERATED)
+            ? '--' . self::INPUT_KEY_KEEP_GENERATED
+            : ''
+        ;
+
+        $this->commandLine->run(
+            sprintf('docker exec -u www-data %s bin/magento setup:upgrade %s --ansi', $container, $option)
+        );
+
+        $pullCommand = $this->getApplication()->find('pull');
+        $pullArguments = new ArrayInput(['files' => ['app/etc/config.php']]);
+
+        $pullCommand->run($pullArguments, $output);
+    }
+}
+

--- a/test/Command/MagentoSetupUpgradeTest.php
+++ b/test/Command/MagentoSetupUpgradeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\WorkflowTest\Command;
+
+use Jh\Workflow\Command\MagentoSetupUpgrade;
+use Jh\Workflow\Command\Pull;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\ArrayInput;
+
+/**
+ * @author Diego Cabrejas <diego@wearejh.com>
+ */
+class MagentoSetupUpgradeTest extends AbstractTestCommand
+{
+    /**
+     * @var ComposerUpdate
+     */
+    private $command;
+
+    /**
+     * @var ObjectProphecy|Application
+     */
+    private $application;
+
+    /**
+     * @var ObjectProphecy|Pull
+     */
+    private $pullCommand;
+
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->command     = new MagentoSetupUpgrade($this->commandLine->reveal());
+        $this->application = $this->prophesize(Application::class);
+        $this->pullCommand = $this->prophesize(Pull::class);
+
+        $this->application->getHelperSet()->willReturn(new HelperSet);
+        $this->application->find('pull')->willReturn($this->pullCommand->reveal());
+
+        $this->command->setApplication($this->application->reveal());
+    }
+
+    public function tearDown()
+    {
+        $this->prophet->checkPredictions();
+    }
+
+    public function testCommandIsConfigured()
+    {
+        $description = 'Upgrades the Magento application and updates the config.php file';
+
+        static::assertEquals('setup:upgrade', $this->command->getName());
+        static::assertEquals($description, $this->command->getDescription());
+        static::assertTrue($this->command->getDefinition()->hasOption(MagentoSetupUpgrade::INPUT_KEY_KEEP_GENERATED));
+    }
+
+    public function testSetupUpgradeCommandWithoutOption()
+    {
+        $this->useValidEnvironment();
+        $this->input
+            ->getOption(MagentoSetupUpgrade::INPUT_KEY_KEEP_GENERATED)
+            ->shouldBeCalled()
+            ->willReturn(false)
+        ;
+
+        $cmd = 'docker exec -u www-data m2-php bin/magento setup:upgrade  --ansi';
+        $this->commandLine->run($cmd)->shouldBeCalled();
+
+        $expectedInput = new ArrayInput(['files' => ['app/etc/config.php']]);
+        $this->pullCommand->run($expectedInput, $this->output)->shouldBeCalled();
+
+        $this->command->execute($this->input->reveal(), $this->output->reveal());
+    }
+
+    public function testSetupUpgradeCommandWithOption()
+    {
+        $this->useValidEnvironment();
+        $this->input
+            ->getOption(MagentoSetupUpgrade::INPUT_KEY_KEEP_GENERATED)
+            ->shouldBeCalled()
+            ->willReturn(true)
+        ;
+
+        $cmd = 'docker exec -u www-data m2-php bin/magento setup:upgrade --keep-generated --ansi';
+        $this->commandLine->run($cmd)->shouldBeCalled();
+
+        $expectedInput = new ArrayInput(['files' => ['app/etc/config.php']]);
+        $this->pullCommand->run($expectedInput, $this->output)->shouldBeCalled();
+
+        $this->command->execute($this->input->reveal(), $this->output->reveal());
+    }
+
+    public function testExceptionThrownIfContainerNameNotFound()
+    {
+        $this->useInvalidEnvironment();
+        $this->expectException(\RuntimeException::class);
+
+        $this->command->execute($this->input->reveal(), $this->output->reveal());
+    }
+}


### PR DESCRIPTION
Add a wrapper command for the Magento  `setup:upgrade` command.
This pulls the `app/etc/config.php` file to the host afterwards.

Reason:
`app/etc/config.php` file needs to be commited to the VCS, therefore changes made to it should always be pulled to the host machine.