### PR TITLE
set no limit on xdebug max data

### DIFF
--- a/templates/docker/php/etc/xdebug.template
+++ b/templates/docker/php/etc/xdebug.template
@@ -3,3 +3,4 @@ xdebug.remote_port = 9000
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = ${XDEBUG_IDE_KEY}
+xdebug.var_display_max_data = -1


### PR DESCRIPTION
allows retrieval of long values (e.g. xml documents) when inspecting/eval-getting values in xdebug

--

This may not be desirable in some cases, depending on how xdebug is being used as holding long values may chew up a lot of memory - but I've not had any problems with this while working Selco M2.

I think it's worth a discussion at least, hence my tagging all seniors for review. Sorry 🙂 