### PR TITLE
install php config -after- building

### DIFF
--- a/templates/docker/app.php.dockerfile
+++ b/templates/docker/app.php.dockerfile
@@ -47,10 +47,6 @@ RUN [ "$BUILD_ENV" != "$PROD_ENV" ] \
     && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini; \
     true
 
-# Configuration files
-COPY .docker/php/etc/custom.template .docker/php/etc/xdebug.template /usr/local/etc/php/conf.d/
-COPY .docker/php/etc/msmtprc.template /etc/msmtprc.template
-
 # Copy in Entrypoint file & Magento installation script
 COPY .docker/php/bin/docker-configure .docker/php/bin/magento-install .docker/php/bin/magento-configure /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-configure /usr/local/bin/magento-install /usr/local/bin/magento-configure
@@ -93,6 +89,10 @@ RUN rm -rf \
 
 RUN find . -user root | xargs chown www-data:www-data \
     && chmod +x bin/magento
+
+# Configuration files
+COPY .docker/php/etc/custom.template .docker/php/etc/xdebug.template /usr/local/etc/php/conf.d/
+COPY .docker/php/etc/msmtprc.template /etc/msmtprc.template
 
 VOLUME ["/var/www"]
 ENTRYPOINT ["/usr/local/bin/docker-configure"]


### PR DESCRIPTION
presently, rebuilding php config changes into image force a full composer install of m2, despite its preexistence in a persisted volume, making a very slow process of tweaking container parameters

by installing php config after composer install, we take advantage of build cache and reduce build times for config changes from >5 minutes to the order of seconds