### PR TITLE
Set `$LINES` and `$COLUMNS` in container

### DIFF
--- a/src/Command/Ssh.php
+++ b/src/Command/Ssh.php
@@ -43,6 +43,19 @@ class Ssh extends Command implements CommandInterface
 
         $user = $input->getOption('root') ? 'root' : 'www-data';
 
-        $this->commandLine->runInteractively(sprintf('docker exec -it -u %s %s bash', $user, $container));
+        $width = trim(`tput cols`);
+        $height = trim(`tput lines`);
+
+        $command = <<<CMD
+docker exec \
+    -it \
+    -u "{$user}" \
+    -e COLUMNS="{$width}" \
+    -e LINES="{$height}" \
+    "{$container}" bash
+CMD
+        ;
+
+        $this->commandLine->runInteractively($command);
     }
 }


### PR DESCRIPTION
When running `workflow ssh`, the tty created by Docker doesn't know how wide (or tall) the host's terminal emulator is. This creates all kinds of trouble when you try to write long commands, and the line wraps, or you want to run Vim, or something.

It's possible to tell Docker how wide the TTY should be by passing `$LINES` and `$COLUMNS` as environment variables. We pick up the values from the `tput` command, which at least works on a mac.

[![asciicast](https://asciinema.org/a/iZb2qjPg207Z9HpEKcsbWjsjw.png)](https://asciinema.org/a/iZb2qjPg207Z9HpEKcsbWjsjw)