### PR TITLE
Build php image using the dockerfile from the docker-compose file

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -48,8 +48,14 @@ class Build extends Command implements CommandInterface
             throw new \RuntimeException('No image specified for PHP container');
         }
 
+        if (!isset($service['build']['dockerfile'])) {
+            throw new \RuntimeException('No dockerfile specified for PHP container');
+        }
+
+        $dockerFile = $service['build']['dockerfile'];
+
         $this->commandLine
-            ->run(sprintf('docker build -t %s -f app.php.dockerfile %s', $service['image'], $buildArg));
+            ->run(sprintf('docker build -t %s -f %s %s', $service['image'], $dockerFile, $buildArg));
 
         $output->writeln('<info>Build complete!</info>');
     }


### PR DESCRIPTION
I know a few projects (including mine G&G) have moved the **app.php.dockerfile** into a directory such as **.docker/php/Dockerfile** in order to keep the root directly clean and organize things better. 

This was breaking the **workflow build** command, which always assumed the docker file was in the root directory and that it is called **app.php.dockerfile**. 

This PR modifies the **build** command so that it uses whatever docker file has been specified in the **docker-compose** files so that it works regardless of where the file is.

**Note** The build context is still hard-coded to the root directory, I can't think of a reason why someone would want the build context to be anything else so I am leaving that hard-coded.