### PR TITLE
Fix stop command destroying everything

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -29,6 +29,7 @@ return [
 
         $app->add($c->get(Command\Start::class));
         $app->add($c->get(Command\Stop::class));
+        $app->add($c->get(Command\Down::class));
         $app->add($c->get(Command\Restart::class));
         $app->add($c->get(Command\Build::class));
         $app->add($c->get(Command\Up::class));
@@ -111,6 +112,7 @@ return [
     Command\Push::class               => DI\object(),
     Command\Start::class              => DI\object(),
     Command\Stop::class               => DI\object(),
+    Command\Down::class               => DI\object(),
     Command\Up::class                 => DI\object(),
     Command\Watch::class              => function (ContainerInterface $c) {
         return new Command\Watch($c->get(WatchFactory::class), $c->get(Files::class));

--- a/src/Command/Down.php
+++ b/src/Command/Down.php
@@ -9,9 +9,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @author Michael Woodward <michael@wearejh.com>
+ * @author Max Bucknell <max@wearejh.com>
  */
-class Stop extends Command implements CommandInterface
+class Down extends Command implements CommandInterface
 {
     use DockerAwareTrait;
 
@@ -29,8 +29,8 @@ class Stop extends Command implements CommandInterface
     public function configure()
     {
         $this
-            ->setName('stop')
-            ->setDescription('Stops the containers running')
+            ->setName('down')
+            ->setDescription('Stop and remove containers, networks, images, and volumes')
             ->addOption('prod', 'p', InputOption::VALUE_OPTIONAL, 'Use when started with --prod / -p');
     }
 
@@ -40,7 +40,7 @@ class Stop extends Command implements CommandInterface
             ? 'docker-compose.prod.yml'
             : 'docker-compose.dev.yml';
 
-        $this->commandLine->run(sprintf('docker-compose -f docker-compose.yml -f %s stop', $envDockerFile));
+        $this->commandLine->run(sprintf('docker-compose -f docker-compose.yml -f %s down', $envDockerFile));
 
         $output->writeln('<info>Containers stopped</info>');
     }


### PR DESCRIPTION
It was the Spring of 2018 when I realised it. Whenever I stopped my project with `workflow stop`, I had to run `composer install` after I restarted. I couldn't go on like this. There had to be a better way.

Upon closer inspection, I learned that Workflow's `stop` command was in fact running Docker Compose's `down` command, which stops containers, subsquently removing those containers, along with all networks and volumes. This meant that `vendor` (and indeed everything else) was being reset to the halcyon days when the container was built.

*I couldn't go on like this. There had to be a better way*, I thought to myself. And luckily for me, there was.

Please find attached a pull request, in which I valiantly fix the `stop` command in Workflow to mnemonically match Docker Compose. Not one for half measures, I included a `down` command to match the old behaviour.