### PR TITLE
Remove the hard requirement on compose dev yml

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -44,15 +44,13 @@ class Build extends Command implements CommandInterface
             throw new \RuntimeException('No image specified for PHP container');
         }
 
-        $dockerFile = $input->getOption('prod')
-            ? 'docker-compose.prod.yml'
-            : 'docker-compose.dev.yml';
-
         $service = $input->getOption('service') ?: 'php';
         $args    = $input->getOption('no-cache') ? '--no-cache' : '';
 
+        $composeFiles = $this->getComposeFileFlags($input->getOption('prod') ? true : false);
+
         $this->commandLine->run(
-            rtrim(sprintf('docker-compose -f docker-compose.yml -f %s build %s %s', $dockerFile, $service, $args))
+            rtrim(sprintf('docker-compose %s build %s %s', $composeFiles, $service, $args))
         );
 
         $output->writeln('<info>Build complete!</info>');

--- a/src/Command/Down.php
+++ b/src/Command/Down.php
@@ -36,11 +36,9 @@ class Down extends Command implements CommandInterface
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $envDockerFile = $input->getOption('prod')
-            ? 'docker-compose.prod.yml'
-            : 'docker-compose.dev.yml';
+        $composeFiles = $this->getComposeFileFlags($input->getOption('prod') ? true : false);
 
-        $this->commandLine->run(sprintf('docker-compose -f docker-compose.yml -f %s down', $envDockerFile));
+        $this->commandLine->run(sprintf('docker-compose %s down', $composeFiles));
 
         $output->writeln('<info>Containers stopped</info>');
     }

--- a/src/Command/Stop.php
+++ b/src/Command/Stop.php
@@ -36,11 +36,9 @@ class Stop extends Command implements CommandInterface
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $envDockerFile = $input->getOption('prod')
-            ? 'docker-compose.prod.yml'
-            : 'docker-compose.dev.yml';
+        $composeFiles = $this->getComposeFileFlags($input->getOption('prod') ? true : false);
 
-        $this->commandLine->run(sprintf('docker-compose -f docker-compose.yml -f %s stop', $envDockerFile));
+        $this->commandLine->run(sprintf('docker-compose %s stop', $composeFiles));
 
         $output->writeln('<info>Containers stopped</info>');
     }

--- a/src/Command/Up.php
+++ b/src/Command/Up.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Up extends Command implements CommandInterface
 {
+    use DockerAwareTrait;
+
     /**
      * @var CommandLine
      */
@@ -37,15 +39,11 @@ class Up extends Command implements CommandInterface
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $envDockerFile = $input->getOption('prod')
-            ? 'docker-compose.prod.yml'
-            : 'docker-compose.dev.yml';
-
         $buildArg = $input->getOption('no-build') ? '' : '--build';
 
-        $this->commandLine->run(
-            rtrim(sprintf('docker-compose -f docker-compose.yml -f %s up -d %s', $envDockerFile, $buildArg))
-        );
+        $composeFiles = $this->getComposeFileFlags($input->getOption('prod') ? true : false);
+
+        $this->commandLine->run(rtrim(sprintf('docker-compose %s up -d %s', $composeFiles, $buildArg)));
 
         // Pull composer cache for future builds
         $pullCommand  = $this->getApplication()->find('pull');

--- a/test/Command/DockerAwareTraitTest.php
+++ b/test/Command/DockerAwareTraitTest.php
@@ -57,8 +57,7 @@ class DockerAwareTraitTest extends AbstractTestCommand
         chdir(__DIR__ . '/../fixtures/missing-docker-files');
         $this->expectException(\RuntimeException::class);
 
-        $message  = 'Could not locate docker files. Are you in the right directory?. Tried to locate ';
-        $message .= 'docker-compose.yml & docker-compose.dev.yml';
+        $message  = 'Could not locate docker-compose.yml file. Are you in the right directory?';
 
         $this->expectExceptionMessage($message);
         $this->implementation->containerNameTest('php');

--- a/test/fixtures/valid-env/docker-compose.prod.yml
+++ b/test/fixtures/valid-env/docker-compose.prod.yml
@@ -1,0 +1,23 @@
+version: '2'
+
+volumes:
+    app-var:
+
+services:
+    nginx:
+        env_file:
+            - .docker/production.env
+
+    php:
+        env_file:
+            - .docker/production.env
+        volumes:
+            - app-var:/var/www/var
+
+    db:
+        env_file:
+            - .docker/production.env
+
+#    rabbitmq:
+#        env_file:
+#            - ./.docker/production.env


### PR DESCRIPTION
This allows us to quitely deprecate using `docker-compose.dev.yml` and `docker-compose.prod.yml` without the immediate need to update all projects. 

